### PR TITLE
Preserve order of lists in JSON -> Erl conversion

### DIFF
--- a/src/json_rec.erl
+++ b/src/json_rec.erl
@@ -146,7 +146,7 @@ keys_rec([{Key, Value}|Rest], Module, Rec) ->
 pl(P, Module) ->
     pl(P,Module,[]).
 pl([],_M,[H]) -> H;
-pl([],_M,Acc) -> Acc;
+pl([],_M,Acc) -> lists:reverse(Acc);
 pl([{Key, {struct,Pl}}|Rest], Module, Acc) ->
     Value = case module_new(Module,Key,undefined) of
                 undefined ->


### PR DESCRIPTION
JSON lists, including proplists, are reversed after calling to_rec.  This fixes the reversal so that Erlang order matches JSON order.
