### PR TITLE
Some fixes

### DIFF
--- a/include/json_rec_types.hrl
+++ b/include/json_rec_types.hrl
@@ -3,7 +3,7 @@
 
 -type proplist() :: list({term(),term()}).
 
--type json_dict() :: {struct, proplist()}.
+-type json_dict() :: {struct, proplist()} | {proplist()}.
 -type json() :: json_dict()|list(term()).
 
 

--- a/rebar.config
+++ b/rebar.config
@@ -3,4 +3,4 @@
     {parse_trans, "", {git, "https://github.com/uwiger/parse_trans.git", {branch, "master"}}}
  ]}.
 {erl_opts, [debug_info]}.
-
+{lib_dirs, ["deps"]}.

--- a/src/json_rec.erl
+++ b/src/json_rec.erl
@@ -205,7 +205,7 @@ to_value({struct, Pl}, Module, _Acc) ->
     pl(Pl,Module);
 to_value({Pl}, Module, _Acc) ->
     pl(Pl,Module);
-to_value([], _Module, Acc) -> Acc;
+to_value([], _Module, Acc) -> lists:reverse(Acc);
 to_value([H|T],Module, Acc) ->
     to_value(T,Module,[to_value(H,Module,[])|Acc]);
 to_value(V,_Module,_Acc) -> V.

--- a/src/json_rec.erl
+++ b/src/json_rec.erl
@@ -62,7 +62,7 @@ rec_keys([], _Record, _Module, _ConvType, Acc) -> Acc;
 rec_keys([Field|Rest],Record,Module, ConvType, Acc) ->
     case module_get(Module, Field, Record) of
         undefined ->
-            rec_keys(Rest, Record, Module, ConvType, [Acc]);
+            rec_keys(Rest, Record, Module, ConvType, Acc);
         Value ->
             Key = list_to_binary(atom_to_list(Field)),
             JsonValue = field_value(Value,Module, ConvType, []),

--- a/src/json_rec.erl
+++ b/src/json_rec.erl
@@ -238,9 +238,14 @@ module_has_rec([M|T],Rec, Act) ->
 
 
 
-module_set(Ms, Kv, Rec) ->
+module_set(Ms, Kv={K,_}, Rec) ->
     M = module_has_rec(Ms,Rec),
-    M:'#set-'([Kv],Rec).
+    case M:'#pos-'(element(1, Rec), K) of
+        0 ->
+            Rec;
+        _ ->
+            M:'#set-'([Kv],Rec)
+    end.
 
 module_rec_fields(Ms, Rec ) ->
     M = module_has_rec(Ms,Rec),

--- a/src/json_rec.erl
+++ b/src/json_rec.erl
@@ -60,10 +60,14 @@ to_json(Record, Module, ConvType) ->
 
 rec_keys([], _Record, _Module, _ConvType, Acc) -> Acc;
 rec_keys([Field|Rest],Record,Module, ConvType, Acc) ->
-    Value = module_get(Module, Field, Record),
-    Key = list_to_binary(atom_to_list(Field)),
-    JsonValue = field_value(Value,Module, ConvType, []),
-    rec_keys(Rest, Record, Module, ConvType, [{Key,JsonValue}|Acc]).
+    case module_get(Module, Field, Record) of
+        undefined ->
+            rec_keys(Rest, Record, Module, ConvType, [Acc]);
+        Value ->
+            Key = list_to_binary(atom_to_list(Field)),
+            JsonValue = field_value(Value,Module, ConvType, []),
+            rec_keys(Rest, Record, Module, ConvType, [{Key,JsonValue}|Acc])
+    end.
 
 field_value(Value, Module, ConvType, _Acc) when is_tuple(Value) ->
     case module_has_rec(Module, Value, false) of
@@ -186,8 +190,6 @@ pl([{Key, {struct,Pl}}|Rest], Module, Acc) ->
 pl([{Key, {Pl}}|Rest], Module, Acc) ->
     Value = pl_subrec_value(Pl, Key, Module),
     pl(Rest, Module, [Value|Acc]);
-pl([{_Key,undefined}|Rest], Module, Acc) ->
-    pl(Rest, Module, [Acc]);
 pl([{Key,Value}|Rest], Module, Acc) ->
     pl(Rest, Module, [{Key,Value}|Acc]).
 

--- a/src/json_rec.erl
+++ b/src/json_rec.erl
@@ -186,6 +186,8 @@ pl([{Key, {struct,Pl}}|Rest], Module, Acc) ->
 pl([{Key, {Pl}}|Rest], Module, Acc) ->
     Value = pl_subrec_value(Pl, Key, Module),
     pl(Rest, Module, [Value|Acc]);
+pl([{_Key,undefined}|Rest], Module, Acc) ->
+    pl(Rest, Module, [Acc]);
 pl([{Key,Value}|Rest], Module, Acc) ->
     pl(Rest, Module, [{Key,Value}|Acc]).
 


### PR DESCRIPTION
Changes:
- keep lists order on translation
- add support for EEP18 record format {[...]}, default behaviour is preserved
- ignore unknown JSON fields
- allow user to specify records for fields as:

new({<<"record_name">>, <<"field_name">>}) -> '#new-dependent_record_name'()
