### PR TITLE
Fix list reversal in to_rec

### DIFF
--- a/src/json_rec.erl
+++ b/src/json_rec.erl
@@ -167,7 +167,7 @@ to_value(V, Module) ->
 
 to_value({struct, Pl}, Module, _Acc) ->
     pl(Pl,Module);
-to_value([], _Module, Acc) -> Acc;
+to_value([], _Module, Acc) -> lists:reverse(Acc);
 to_value([H|T],Module, Acc) ->
     to_value(T,Module,[to_value(H,Module,[])|Acc]);
 to_value(V,_Module,_Acc) -> V.


### PR DESCRIPTION
If one of the values passed to to_rec is a list, it will be reversed in the result. This patch fixes it.
